### PR TITLE
Multitable

### DIFF
--- a/append_db/src/backend/class.rs
+++ b/append_db/src/backend/class.rs
@@ -27,7 +27,7 @@ pub trait State {
     type Err: Debug + Error + 'static;
 
     /// Table holding updates
-    const TABLE: &'static str;
+    const TABLE: &'static str = "updates";
     
     /// Update the state with incremental part
     fn update(&mut self, upd: Self::Update) -> Result<(), Self::Err>;

--- a/append_db/src/backend/class.rs
+++ b/append_db/src/backend/class.rs
@@ -26,6 +26,9 @@ pub trait State {
     /// Update error
     type Err: Debug + Error + 'static;
 
+    /// Table holding updates
+    const TABLE: &'static str;
+    
     /// Update the state with incremental part
     fn update(&mut self, upd: Self::Update) -> Result<(), Self::Err>;
 }

--- a/append_db/src/lib.rs
+++ b/append_db/src/lib.rs
@@ -25,6 +25,7 @@ mod tests {
     impl State for State0 {
         type Update = Update0;
         type Err = Infallible;
+        const TABLE: &'static str = "updates";
 
         fn update(&mut self, upd: Update0) -> Result<(), Self::Err> {
             match upd {

--- a/append_db_postgres/migrations/0001_create_scheme.sql
+++ b/append_db_postgres/migrations/0001_create_scheme.sql
@@ -5,3 +5,11 @@ create table updates(
     tag text not null,
     body jsonb not null
 );
+
+create table updates2(
+    id serial primary key,
+    created timestamp not null,
+    version smallint not null,
+    tag text not null,
+    body jsonb not null
+);

--- a/append_db_postgres/src/backend.rs
+++ b/append_db_postgres/src/backend.rs
@@ -61,16 +61,14 @@ impl<
         let tag = format!("{}", update.get_tag());
         let body = update.serialize_untagged()?;
         let pool = self.pool.lock().await;
-        let query = format!("insert into {} (created, version, tag, body) values ('{}', {}, '{}', '{}')",
-            St::TABLE,
-            now,
-            update.get_version() as i16,
-            tag,
-            body,
-        );
-        sqlx::query(&query)
-        .execute(pool.deref())
-        .await?;
+        let query = format!("insert into {} (created, version, tag, body) values ($1, $2, $3, $4)", St::TABLE);
+        let query = sqlx::query(&query)
+            .bind(now)
+            .bind(update.get_version() as i16)
+            .bind(tag)
+            .bind(body)
+            .execute(pool.deref());
+        query.await?;
         Ok(())
     }
 

--- a/append_db_postgres/src/lib.rs
+++ b/append_db_postgres/src/lib.rs
@@ -24,6 +24,17 @@ mod tests {
         field: u64,
     }
 
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, VersionedState)]
+    struct State1 {
+        field: String
+    }
+
+    #[derive(Clone, Debug, PartialEq, HasUpdateTag)]
+    enum Update1{
+        Append(String),
+        Set(String)
+    }
+
     #[derive(Clone, Debug, PartialEq, HasUpdateTag)]
     enum Update0 {
         Add(u64),
@@ -33,12 +44,26 @@ mod tests {
     impl State for State0 {
         type Update = Update0;
         type Err = Infallible;
-        const TABLE: &'static str = "updates";
 
         fn update(&mut self, upd: Update0) -> Result<(), Self::Err> {
             match upd {
                 Update0::Add(v) => self.field += v,
                 Update0::Set(v) => self.field = v,
+            }
+            Ok(())
+        }
+    }
+
+    impl State for State1 {
+        type Update = Update1;
+        type Err = Infallible;
+
+        const TABLE: &'static str = "updates2";
+
+        fn update(&mut self, upd: Self::Update) -> Result<(), Self::Err> {
+            match upd {
+                Update1::Append(s) => self.field.push_str(s.as_str()),
+                Update1::Set(s) => self.field = s,
             }
             Ok(())
         }
@@ -52,6 +77,19 @@ mod tests {
     }
 
     #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
+    async fn two_tables_postgres_init() {
+        let postgres = Postgres::new(pool);
+        let state0 = State0 { field: 42 };
+        let db = AppendDb::new(postgres.clone(), state0.clone());
+        assert_eq!(db.get().await.deref(), &state0);
+
+        let state1 = State1 {field: String::new()};
+        let postgres1 = postgres.duplicate();
+        let db = AppendDb::new(postgres1, state1.clone());
+        assert_eq!(db.get().await.deref(), &state1);
+    }    
+
+    #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
     async fn postgres_updates() {
         let state0 = State0 { field: 42 };
         let mut db = AppendDb::new(Postgres::new(pool), state0.clone());
@@ -60,6 +98,25 @@ mod tests {
         db.update(Update0::Set(4)).await.expect("update");
         assert_eq!(db.get().await.deref().field, 4);
     }
+
+    #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
+    async fn two_tables_test_updates(){
+        let postgres = Postgres::new(pool);
+        let state0 = State0 { field: 42 };
+        let mut db = AppendDb::new(postgres.clone(), state0.clone());
+        db.update(Update0::Add(1)).await.expect("update");
+        assert_eq!(db.get().await.deref().field, 43);
+        db.update(Update0::Set(4)).await.expect("update");
+        assert_eq!(db.get().await.deref().field, 4);
+
+        let state1 = State1 {field: String::new()};
+        let postgres1 = postgres.duplicate();
+        let mut db1 = AppendDb::new(postgres1, state1.clone());
+        db1.update(Update1::Append("Hello".to_string())).await.expect("update");
+        assert_eq!(db1.get().await.deref().field, "Hello".to_string());
+        db1.update(Update1::Set("Hello world!".to_string())).await.expect("update");
+        assert_eq!(db1.get().await.deref().field, "Hello world!".to_string());        
+    }     
 
     #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
     async fn postgres_snapshot() {
@@ -73,6 +130,26 @@ mod tests {
     }
 
     #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
+    async fn two_tables_postgres_snapshot() {
+        let postgres0 = Postgres::new(pool);
+        let state0 = State0 { field: 42 };
+        let mut db = AppendDb::new(postgres0.clone(), state0.clone());
+        db.update(Update0::Add(1)).await.expect("update");
+        db.snapshot().await.expect("snapshot");
+
+        let upds = db.backend.updates().await.expect("collected");
+        assert_eq!(upds, vec![SnapshotedUpdate::Snapshot(State0 { field: 43 })]);
+
+        let postgres1 = postgres0.duplicate();
+        let state1 = State1 { field: "Hello".to_string() };
+        let mut db1 = AppendDb::new(postgres1, state1.clone());
+        db1.update(Update1::Append(" world!".to_string())).await.expect("update");
+        db1.snapshot().await.expect("snapshot");
+        let upds1 = db1.backend.updates().await.expect("collected");
+        assert_eq!(upds1, vec![SnapshotedUpdate::Snapshot(State1 { field: "Hello world!".to_string() })]);
+    }    
+
+    #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
     async fn postgres_reconstruct() {
         let state0 = State0 { field: 42 };
         let mut db = AppendDb::new(Postgres::new(pool), state0.clone());
@@ -84,6 +161,26 @@ mod tests {
     }
 
     #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
+    async fn two_tables_postgres_reconstruct() {
+        let postgres = Postgres::new(pool);
+        let state0 = State0 { field: 42 };
+        let mut db = AppendDb::new(postgres.clone(), state0.clone());
+        db.update(Update0::Add(1)).await.expect("update");
+        db.update(Update0::Set(4)).await.expect("update");
+        db.load().await.expect("load");
+        assert_eq!(db.get().await.deref().field, 4);
+
+        let state1 = State1 {field: String::new()};
+        let postgres1 = postgres.duplicate();
+        let mut db1 = AppendDb::new(postgres1, state1.clone());
+        db1.update(Update1::Append("Hello".to_string())).await.expect("update");
+        db1.update(Update1::Set("Hello world!".to_string())).await.expect("update");
+
+        db1.load().await.expect("load");
+        assert_eq!(db1.get().await.deref().field, "Hello world!".to_string());
+    }    
+
+    #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
     async fn postgres_reconstruct_snapshot() {
         let state0 = State0 { field: 42 };
         let mut db = AppendDb::new(Postgres::new(pool), state0.clone());
@@ -93,5 +190,29 @@ mod tests {
 
         db.load().await.expect("load");
         assert_eq!(db.get().await.deref().field, 4);
+    }
+
+    #[sqlx_database_tester::test(pool(variable = "pool", migrations = "./migrations"))]
+    async fn two_tables_postgres_reconstruct_snapshot() {
+        let postgres = Postgres::new(pool);
+        let state0 = State0 { field: 42 };
+        let mut db = AppendDb::new(postgres.clone(), state0.clone());
+        db.update(Update0::Add(1)).await.expect("update");
+        db.snapshot().await.expect("snapshot");
+        db.update(Update0::Set(4)).await.expect("update");
+
+        db.load().await.expect("load");
+        assert_eq!(db.get().await.deref().field, 4);
+
+        let state1 = State1 {field: String::new()};
+        let postgres1 = postgres.duplicate();
+        let mut db1 = AppendDb::new(postgres1, state1.clone());
+
+        db1.update(Update1::Append("Hello".to_string())).await.expect("update");
+        db1.snapshot().await.expect("snapshot");
+        db1.update(Update1::Set("Hello world!".to_string())).await.expect("update");
+
+        db1.load().await.expect("load");
+        assert_eq!(db1.get().await.deref().field, "Hello world!".to_string());
     }
 }

--- a/append_db_postgres/src/lib.rs
+++ b/append_db_postgres/src/lib.rs
@@ -33,6 +33,7 @@ mod tests {
     impl State for State0 {
         type Update = Update0;
         type Err = Infallible;
+        const TABLE: &'static str = "updates";
 
         fn update(&mut self, upd: Update0) -> Result<(), Self::Err> {
             match upd {

--- a/append_db_postgres/src/lib.rs
+++ b/append_db_postgres/src/lib.rs
@@ -208,11 +208,11 @@ mod tests {
         let postgres1 = postgres.duplicate();
         let mut db1 = AppendDb::new(postgres1, state1.clone());
 
-        db1.update(Update1::Append("Hello".to_string())).await.expect("update");
+        db1.update(Update1::Append("Hello ') drop table updates2;".to_string())).await.expect("update");
         db1.snapshot().await.expect("snapshot");
-        db1.update(Update1::Set("Hello world!".to_string())).await.expect("update");
+        db1.update(Update1::Set("Hello world! ') drop table updates2;".to_string())).await.expect("update");
 
         db1.load().await.expect("load");
-        assert_eq!(db1.get().await.deref().field, "Hello world!".to_string());
+        assert_eq!(db1.get().await.deref().field, "Hello world! ') drop table updates2;".to_string());
     }
 }

--- a/append_db_postgres_derive/src/lib.rs
+++ b/append_db_postgres_derive/src/lib.rs
@@ -18,15 +18,13 @@ pub fn versioned_state_derive(input: TokenStream) -> TokenStream {
 fn impl_versioned_state(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let gen = quote! {
-        use append_db_postgres::update::{UpdateBodyError, SNAPSHOT_TAG};
-
         impl VersionedState for #name {
             fn deserialize_with_version(
                 version: u16,
                 value: serde_json::Value,
             ) -> Result<Self, append_db_postgres::update::UpdateBodyError> {
                 serde_json::from_value(value.clone()).map_err(|e| {
-                    append_db_postgres::update::UpdateBodyError::Deserialize(version, std::borrow::Cow::Borrowed(SNAPSHOT_TAG), e, value)
+                    append_db_postgres::update::UpdateBodyError::Deserialize(version, std::borrow::Cow::Borrowed(append_db_postgres::update::SNAPSHOT_TAG), e, value)
                 })
             }
             fn get_version(&self) -> u16 {
@@ -35,7 +33,7 @@ fn impl_versioned_state(ast: &syn::DeriveInput) -> TokenStream {
             #[allow(clippy::needless_question_mark)]
             fn serialize(&self) -> Result<serde_json::Value, append_db_postgres::update::UpdateBodyError> {
                 Ok(serde_json::to_value(&self)
-                    .map_err(|e| append_db_postgres::update::UpdateBodyError::Serialize(std::borrow::Cow::Borrowed(SNAPSHOT_TAG), e))?)
+                    .map_err(|e| append_db_postgres::update::UpdateBodyError::Serialize(std::borrow::Cow::Borrowed(append_db_postgres::update::SNAPSHOT_TAG), e))?)
             }
         }
     };

--- a/shell.nix
+++ b/shell.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
   export PG_DATA=./pgsql-data
   export PG_PORT=5435
   if [ ! -d "$PG_DATA" ]; then
-    initdb $PG_DATA --auth=trust
+    initdb $PG_DATA --auth=trust --no-locale --encoding=UTF8
     echo "port = $PG_PORT" >> $PG_DATA/postgresql.conf
     echo "unix_socket_directories = '$PWD'" >> $PG_DATA/postgresql.conf
     pg_ctl start -D$PG_DATA -l postgresql.log


### PR DESCRIPTION
Add support for multiple tables for different states on the same db. 

* Add static field `TABLE &str` which denotes the table the State is going to use. Default = "updates" for backward compatibility
* Specify `append_db_postgres::update::SNAPSHOT_TAG` in `append_db_postgres_derive` to allow multiple derivations to not collide on imports
* Queries for `append_db_postgress` are not via macros, but partially via `format!` and `sqlx::query` which allows to bind table name.

``` rust
        let query = format!("insert into {} (created, version, tag, body) values ($1, $2, $3, $4)", St::TABLE);
        let query = sqlx::query(&query)
            .bind(now)
            .bind(update.get_version() as i16)
            .bind(tag)
            .bind(body)
            .execute(pool.deref());
        query.await?;
```

values are screened from sql injections but St::TABLE is not.

If for some reason a developer decided to 

``` rust

impl State for SomeType{

  const TABLE: &'static str = "; drop table updates";
...
}
```

well, they are idiot and you should not give them access to your DB